### PR TITLE
Align url handler externalizer's rewriteElements config to the archetype best practise.

### DIFF
--- a/bundles/core/src/main/webapp/app-config/rewriter/rewriter-html.json
+++ b/bundles/core/src/main/webapp/app-config/rewriter/rewriter-html.json
@@ -31,6 +31,7 @@
   /* Configure HTML elements/attributes to rewrite */
   "transformer-wcm-io-urlhandler-externalizer": {
     "rewriteElements": [
+      "a:href",
       "img:src",
       "link:href",
       "script:src",

--- a/changes.xml
+++ b/changes.xml
@@ -27,6 +27,9 @@
       <action type="update" dev="sseifert">
         Switch to AEM 6.2 and JUnit 5.
       </action>
+      <action type="update" dev="bdang">
+        Align url handler externalizer's rewriteElements config to the archetype best practise.
+      </action>
     </release>
 
     <release version="1.2.2" date="2018-08-27">


### PR DESCRIPTION
Should we algin our sample project to the best practise available in the archetype?

The archetype also transforms `a:href` see:
https://github.com/wcm-io/wcm-io-maven-archetype-aem/blob/develop/src/main/resources/archetype-resources/bundles/core/src/main/webapp/app-config/rewriter/rewriter-html.json#L34